### PR TITLE
Run the build using the latest repo2docker version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,3 +27,4 @@ jobs:
         DOCKER_REGISTRY: "quay.io"
 
         IMAGE_NAME: "ccsf/jupyterhub"
+        FORCE_REPO2DOCKER_VERSION: jupyter-repo2docker==2025.12.0


### PR DESCRIPTION
Using the latest repo2docker version will allow user servers to start even if they've hit their storage quota (set via `2i2c-org/jupyterhub-home-nfs`).

This is because, in the previous version, repo2docker was trying to write some logs to the location set though `REPO_DIR`, which is the user's home directory by default (if not overridden like in https://github.com/2i2c-org/hub-user-image-template/blob/e0a2578e66825134accccbd34b36ca2802e29079/.github/workflows/build.yaml#L40-L44)

Normally, I believe, just re-building the image will pick up the latest version of repo2docker, because repo2docker action installs directly from the main branch. However, explicitly pinning makes it more intentional and allows for better version control.

https://github.com/2i2c-org/infrastructure/issues/7182 and the issues linked there have more context about this.